### PR TITLE
flake8-commas EOL

### DIFF
--- a/docs/pages/usage/violations/index.rst
+++ b/docs/pages/usage/violations/index.rst
@@ -30,7 +30,6 @@ Plugin                         Codes
 -----------------------------  ------
 flake8-bugbear                 `B001 - B008 <https://github.com/PyCQA/flake8-bugbear#list-of-warnings>`_
 flake8-comprehensions          `C400 - C411 <https://github.com/adamchainz/flake8-comprehensions>`_
-flake8-commas                  `C812 - C819 <https://pypi.org/project/flake8-commas/>`_
 mccabe                         `C901 <http://flake8.pycqa.org/en/latest/user/error-codes.html>`_
 flake8-docstrings              `D100 - D417 <https://www.pydocstyle.org/en/latest/error_codes.html>`_
 pycodestyle                    `E001 - E902, W001 - W606 <http://pycodestyle.pycqa.org/en/latest/intro.html#error-codes>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,10 @@ python = ">=3.8.1,<4.0"
 
 flake8 = ">5"
 attrs = "*"
-setuptools = "*"  # only needed for flake8-commas
 typing_extensions = ">=4.0,<5.0"
 astor = "^0.8"
 pygments = "^2.4"
 
-flake8-commas = "^2.0"
 flake8-quotes = "^3.0"
 flake8-comprehensions = "^3.1"
 flake8-docstrings = "^1.3"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -13,7 +13,6 @@ import subprocess
 PLUGINS = (
     'B002',  # flake8-bugbear
     'C400',  # flake8-comprehensions
-    'C819',  # flake8-commas
     'D103',  # flake8-docstring
     'E225',  # pycodestyle
     'E800',  # flake8-eradicate


### PR DESCRIPTION
Looks like `flake8-commas` isn't necessary anymore.   From their [project description](https://pypi.org/project/flake8-commas/):

> Note: [Black](https://pypi.org/project/black/), the uncompromising Python code formatter, or [add-trailing-comma](https://github.com/asottile/add-trailing-comma) can do all this comma insertion automatically. We recommend you use one of those tools instead.

Had to fix this for the Django5/Python3.12 upgrade.